### PR TITLE
Replaced GetClients with safer GetClientIdByIndex

### DIFF
--- a/scripting/include/websocket/ws.inc
+++ b/scripting/include/websocket/ws.inc
@@ -310,13 +310,14 @@ methodmap WebSocketServer < Handle
   public native bool DisconnectClient(const char[] clientId);
 
   /**
-  * Get handles for all connected clients
+  * Gets a client ID by index
   *
-  * @param buffer           Array to store client handles
-  * @param maxSize          Maximum size of the array
-  * @return                 Number of handles stored
+  * @param index       Index of the client ID to retrieve
+  * @param buffer      String buffer to store the ID
+  * @param maxlength   Maximum length of the buffer
+  * @return            true on success, false if index is invalid
   */
-  public native int GetClients(WebSocket[] buffer, int maxSize);
+  public native bool GetClientIdByIndex(int index, char[] buffer, int maxlength);
 
   /**
   * Start the WebSocket server
@@ -339,6 +340,13 @@ methodmap WebSocketServer < Handle
   * Retrieves Per message deflate is enable
   */
   public native void IsDeflateEnabled();
+
+  /**
+  * Maximum length of client IDs (including null terminator)
+  */
+  property int MaxClientIdLength {
+    public native get();
+  }
 
   /**
   * Retrieves connected clients

--- a/src/smsdk_config.h
+++ b/src/smsdk_config.h
@@ -3,7 +3,7 @@
 
 #define SMEXT_CONF_NAME			"SourceMod WebSocket Extension"
 #define SMEXT_CONF_DESCRIPTION	"Provide JSON and WebSocket Native"
-#define SMEXT_CONF_VERSION		"1.0.4"
+#define SMEXT_CONF_VERSION		"1.0.5"
 #define SMEXT_CONF_AUTHOR		"ProjectSky"
 #define SMEXT_CONF_URL			"https://github.com/ProjectSky/sm-ext-websocket"
 #define SMEXT_CONF_LOGTAG		"websocket"

--- a/src/ws_server.cpp
+++ b/src/ws_server.cpp
@@ -160,3 +160,15 @@ bool WebSocketServer::disconnectClient(const std::string& clientId) {
 	}
 	return false;
 }
+
+std::vector<std::string> WebSocketServer::getClientIds() {
+    std::vector<std::string> clientIds;
+
+    auto clients = m_webSocketServer.getClients();
+
+    for (const auto& client : clients) {
+        clientIds.push_back(client.second);
+    }
+
+    return clientIds;
+}

--- a/src/ws_server.h
+++ b/src/ws_server.h
@@ -15,6 +15,7 @@ public:
 	void broadcastMessage(const std::string& message);
 	bool sendToClient(const std::string& clientId, const std::string& message);
 	bool disconnectClient(const std::string& clientId);
+	std::vector<std::string> getClientIds();
 	
 	ix::WebSocketServer m_webSocketServer;
 	Handle_t m_webSocketServer_handle = BAD_HANDLE;


### PR DESCRIPTION
## WebSocket Client ID Handling Improvements

### Changes
- Replaced `GetClients` with safer `GetClientIdByIndex` method
- Added `MaxClientIdLength` property for dynamic buffer sizing
- More idiomatic SourceMod API usage

### Migration Example
```sourcepawn
int maxLen = wsServer.MaxClientIdLength;
char[] buffer = new char[maxLen];
if (wsServer.GetClientIdByIndex(i, buffer, maxLen)) {
    // Use buffer...
    PrintToServer("Client ID: %s", buffer);
}