### PR TITLE
Add ws_GetHeader for WebSocketServer and GetClientById helper

### DIFF
--- a/scripting/include/websocket/ws.inc
+++ b/scripting/include/websocket/ws.inc
@@ -295,6 +295,17 @@ methodmap WebSocketServer < Handle
   public native void BroadcastMessage(const char[] message);
 
   /**
+  * Retrieves the value of a specific HTTP header from a connected WebSocket client.
+  *
+  * @param clientId          The unique ID of the client.
+  * @param headerKey         The name of the HTTP header to retrieve.
+  * @param buffer            The buffer to store the retrieved header value.
+  * @param maxlength         The maximum number of characters to write to the buffer (including null terminator).
+  * @return                  True if the header was found and written to the buffer, false otherwise.
+  */
+  public native bool GetHeader(const char[] clientId, const char[] headerKey, char[] buffer, int maxlength);
+
+  /**
   * Send a message to the client
   *
   * @param clientId          client id

--- a/src/ws_natives_server.cpp
+++ b/src/ws_natives_server.cpp
@@ -279,6 +279,36 @@ static cell_t ws_IsDeflateEnabled(IPluginContext *pContext, const cell_t *params
 	return pWebsocketServer->m_webSocketServer.isPerMessageDeflateEnabled();
 }
 
+static cell_t ws_GetHeader(IPluginContext *pContext, const cell_t *params)
+{
+	WebSocketServer* pWebsocketServer = GetWsServerPointer(pContext, params[1]);
+
+	if (!pWebsocketServer)
+	{
+		return 0;
+	}
+
+	char *clientId, *headerKey;
+	pContext->LocalToString(params[2], &clientId);
+	pContext->LocalToString(params[3], &headerKey);
+
+	ix::WebSocketHttpHeaders headers;
+	if (!pWebsocketServer->getClientHeaders(clientId, headers))
+	{
+		return 0;
+	}
+
+	auto it = headers.find(headerKey);
+	if (it == headers.end())
+	{
+		return 0;
+	}
+
+	pContext->StringToLocal(params[4], params[5], it->second.c_str());
+
+	return 1;
+}
+
 static cell_t ws_GetClientIdByIndex(IPluginContext *pContext, const cell_t *params)
 {
 	WebSocketServer *pWebsocketServer = GetWsServerPointer(pContext, params[1]);
@@ -332,6 +362,7 @@ const sp_nativeinfo_t ws_natives_server[] =
 	{"WebSocketServer.BroadcastMessage",       ws_BroadcastMessage},
 	{"WebSocketServer.SendMessageToClient",    ws_SendMessageToClient},
 	{"WebSocketServer.DisconnectClient",       ws_DisconnectClient},
+	{"WebSocketServer.GetHeader",              ws_GetHeader},
 	{"WebSocketServer.ClientsCount.get",       ws_GetClientsCount},
 	{"WebSocketServer.EnablePong.get",         ws_SetOrGetPongEnable},
 	{"WebSocketServer.EnablePong.set",         ws_SetOrGetPongEnable},

--- a/src/ws_server.h
+++ b/src/ws_server.h
@@ -15,6 +15,7 @@ public:
 	bool sendToClient(const std::string& clientId, const std::string& message);
 	bool disconnectClient(const std::string& clientId);
 	std::vector<std::string> getClientIds();
+	bool getClientHeaders(const std::string& clientId, ix::WebSocketHttpHeaders& outHeaders);
 	
 	ix::WebSocketServer m_webSocketServer;
 	Handle_t m_webSocketServer_handle = BAD_HANDLE;
@@ -26,6 +27,16 @@ public:
 	IChangeableForward *pOpenForward = nullptr;
 	IChangeableForward *pCloseForward = nullptr;
 	IChangeableForward *pErrorForward = nullptr;
+
+	std::shared_ptr<ix::WebSocket> GetClientById(const std::string& clientId)
+	{
+		for (const auto& [websocket, id] : m_webSocketServer.getClients())
+		{
+			if (id == clientId) return websocket;
+		}
+		
+		return nullptr;
+	}
 
 	static std::string GetRemoteAddress(const std::shared_ptr<ix::ConnectionState>& connectionState) {
 		return connectionState->getRemoteIp() + ":" + std::to_string(connectionState->getRemotePort());


### PR DESCRIPTION
This PR introduces the ws_GetHeader native for WebSocketServer, allowing header retrieval without needing a client handle. It also adds a GetClientById helper function to ws_server.h for cleaner internal client lookup.