### PR TITLE
Build against both SourceMod 1.12 (API v8) and 1.13 (API v9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           echo "CXX=clang++" >> $GITHUB_ENV
 
       - name: Getting SourceMod
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: alliedmodders/sourcemod
           ref: ${{ matrix.sm.ref }}
@@ -61,25 +61,24 @@ jobs:
           fetch-depth: 1
 
       - name: Setting up Python and AMBuild
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.14'
           cache: 'pip'
 
       - name: Install AMBuild
         run: pip install git+https://github.com/alliedmodders/ambuild
 
       - name: Getting own repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: extension
           submodules: recursive
 
-      - uses: microsoft/setup-msbuild@v2
+      - uses: microsoft/setup-msbuild@v3
         if: runner.os == 'Windows'
         with:
           msbuild-architecture: x64
-          vs-version: '[17.0,18.0)'
 
       - name: Compiling ${{ github.event.repository.name }} files
         working-directory: extension
@@ -90,7 +89,7 @@ jobs:
           ambuild
 
       - name: Uploading package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sm-ext-websocket-${{ matrix.os_short }}-${{ matrix.sm.label }}-${{ env.GITHUB_SHA_SHORT }}
           path: extension/build/package
@@ -103,7 +102,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: extension
           sparse-checkout: |
@@ -123,7 +122,7 @@ jobs:
         run: echo "${{ github.event.head_commit.message }}" >> release_notes.md
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 
@@ -135,7 +134,7 @@ jobs:
           done
 
       - name: Update Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.get_version.outputs.version }}
           name: Release ${{ steps.get_version.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,17 @@ permissions:
 
 jobs:
   build:
-    name: build on ${{ matrix.os_short }}
+    name: build on ${{ matrix.os_short }} (${{ matrix.sm.label }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-22.04]
+        sm:
+          - label: sm1.13
+            ref: master
+          - label: sm1.12
+            ref: "1.12-dev"
         include:
           - os: windows-latest
             os_short: win
@@ -50,7 +55,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: alliedmodders/sourcemod
-          ref: master
+          ref: ${{ matrix.sm.ref }}
           path: sourcemod
           submodules: recursive
           fetch-depth: 1
@@ -87,7 +92,7 @@ jobs:
       - name: Uploading package
         uses: actions/upload-artifact@v4
         with:
-          name: sm-ext-websocket-${{ matrix.os_short }}-${{ env.GITHUB_SHA_SHORT }}
+          name: sm-ext-websocket-${{ matrix.os_short }}-${{ matrix.sm.label }}-${{ env.GITHUB_SHA_SHORT }}
           path: extension/build/package
           retention-days: 5
 


### PR DESCRIPTION
SourceMod bumped the extension interface API to v9 on master, and now rejects any extensions with a version less than that.
We should build the extension for both API versions.

This PR also updates the action versions to get rid of warnings.